### PR TITLE
fix: garante que a variável será calculada como int

### DIFF
--- a/src/Bancos/BoletoSicoob.php
+++ b/src/Bancos/BoletoSicoob.php
@@ -50,7 +50,7 @@ class BoletoSicoob implements NossoNumeroInterface
                 $constante = 7;
                 $cont = 0;
             }
-            $calculoDv = $calculoDv + (substr($sequencia, $num, 1) * $constante);
+            $calculoDv = $calculoDv + ((int) substr($sequencia, $num, 1) * $constante);
         }
 
         $Resto = $calculoDv % 11;


### PR DESCRIPTION
[2024-07-08 07:14:45] prod.ERROR: Unsupported operand types: int * string {"userId":3406864,"email":"marmatheusmarques1020@gmail.com","exception":"[object] (TypeError(code: 0): Unsupported operand types: int * string at /var/www/html/vendor/bitis/boletos-nosso-numero/src/Bancos/BoletoSicoob.php:53)